### PR TITLE
Add FetchBookData command to fetch book data from Google Books API

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+language: "jp"
+early_access: false
+reviews:
+    request_changes_workflow: false
+    high_level_summary: true
+    poem: true
+    review_status: true
+    collapse_walkthrough: false
+    path_filters:
+        - "!**/.xml"
+    path_instructions:
+        - path: "**/*.js"
+          instructions: "Review the JavaScript code for conformity with the Google JavaScript style guide, highlighting any deviations."
+        - path: "tests/**/*"
+          instructions: |
+              "Assess the unit test code employing the Mocha testing framework. Confirm that:
+              - The tests adhere to Mocha's established best practices.
+              - Test descriptions are sufficiently detailed to clarify the purpose of each test."
+    auto_review:
+        enabled: true
+        ignore_title_keywords:
+            - "WIP"
+            - "DO NOT MERGE"
+        drafts: false
+        base_branches:
+            - "develop"
+            - "feature/*"
+chat:
+    auto_reply: true

--- a/app/Console/Commands/FetchBookData.php
+++ b/app/Console/Commands/FetchBookData.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class FetchBookData extends Command
+{
+    /**
+     * 出版社、ジャンルを引数にとり、Google Books APIから書籍情報を取得する
+     *
+     * @var string
+     */
+    protected $signature = 'fetch:book {publisher} {genre}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Get book data from Google Books API';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // 出版社、ジャンルを取得
+        $publisher = $this->argument('publisher');
+        $genre = $this->argument('genre');
+
+        // Google Books APIから書籍情報を取得
+    }
+}


### PR DESCRIPTION
This pull request adds a new command called FetchBookData to the application. This command allows users to fetch book data from the Google Books API by providing the publisher and genre as arguments. The command is implemented in the FetchBookData class, which extends the Command class. The command can be executed by running the "fetch:book" command in the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- CodeRabbit AIツールの設定を追加しました。
	- 出版社とジャンルに基づいてGoogle Books APIから書籍データを取得する新しいコンソールコマンドを導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->