### PR TITLE
Add new models and migrations for publishers, categories, genres, book-genres, and book-categories

### DIFF
--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Book extends Model
+{
+    use HasFactory;
+
+    // テーブル名
+    protected $table = 'books';
+
+    // 可変項目
+    /** @var array */
+    protected $fillable =
+    [
+        'publisher_id',
+        'isbn',
+        'title',
+        'author',
+        'published_date',
+        'image_url',
+        'description',
+        'price',
+    ];
+
+    /**
+     * 出版社テーブルとのリレーション
+     *
+     * @return BelongsTo
+     */
+    public function publisher(): BelongsTo
+    {
+        return $this->belongsTo(Publisher::class);
+    }
+
+    /**
+     * カテゴリテーブルとのリレーション
+     *
+     * @return BelongsToMany
+     */
+    public function categories(): BelongsToMany
+    {
+        return $this->belongsToMany(Category::class, 'book_category');
+    }
+
+    /**
+     * ジャンルテーブルとのリレーション
+     *
+     * @return BelongsToMany
+     */
+    public function genres(): BelongsToMany
+    {
+        return $this->belongsToMany(Genre::class, 'book_genre');
+    }
+}

--- a/app/Models/BookCategory.php
+++ b/app/Models/BookCategory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BookCategory extends Model
+{
+    use HasFactory;
+
+    // テーブル名
+    protected $table = 'book_category';
+
+    // 可変項目
+    /** @var array */
+    protected $fillable =
+    [
+        'book_id',
+        'category_id',
+    ];
+
+    /**
+     * 本テーブルとのリレーション
+     *
+     * @return BelongsTo
+     */
+    public function book(): BelongsTo
+    {
+        return $this->belongsTo(Book::class);
+    }
+
+    /**
+     * カテゴリテーブルとのリレーション
+     *
+     * @return BelongsTo
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/app/Models/BookGenre.php
+++ b/app/Models/BookGenre.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BookGenre extends Model
+{
+    use HasFactory;
+
+    // テーブル名
+    protected $table = 'book_genre';
+
+    // 可変項目
+    /** @var array */
+    protected $fillable =
+    [
+        'book_id',
+        'genre_id',
+    ];
+
+    /**
+     * 本テーブルとのリレーション
+     *
+     * @return BelongsTo
+     */
+    public function book(): BelongsTo
+    {
+        return $this->belongsTo(Book::class);
+    }
+
+    /**
+     * ジャンルテーブルとのリレーション
+     *
+     * @return BelongsTo
+     */
+    public function genre(): BelongsTo
+    {
+        return $this->belongsTo(Genre::class);
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    protected  $table = 'categories';
+
+    /** @var array */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * 本テーブルとのリレーション
+     *
+     * @return BelongsToMany
+     */
+    public function books(): BelongsToMany
+    {
+        return $this->belongsToMany(Book::class, 'book_category');
+    }
+}

--- a/app/Models/Genre.php
+++ b/app/Models/Genre.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Genre extends Model
+{
+    use HasFactory;
+
+    // テーブル名
+    protected $table = 'genres';
+
+    // 可変項目
+    /** @var array */
+    protected $fillable =
+    [
+        'name',
+    ];
+
+    /**
+     * 本テーブルとのリレーション
+     *
+     * @return BelongsToMany
+     */
+    public function books(): BelongsToMany
+    {
+        return $this->belongsToMany(Book::class, 'book_genre');
+    }
+}

--- a/app/Models/Publisher.php
+++ b/app/Models/Publisher.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Publisher extends Model
+{
+    use HasFactory;
+
+    // テーブル名
+    protected $table = 'publishers';
+
+    // 可変項目
+    /** @var array */
+    protected $fillable =
+    [
+        'name',
+    ];
+
+    /**
+     * 本テーブルとのリレーション
+     *
+     * @return HasMany
+     */
+    public function books(): HasMany
+    {
+        return $this->hasMany(Book::class);
+    }
+
+}

--- a/database/database_schema.dbml
+++ b/database/database_schema.dbml
@@ -1,0 +1,47 @@
+Project techBookShelf {
+    database_type: 'mysql'
+    Note: '''
+     techBookShelf Database
+    '''
+}
+
+Table books {
+  id int [pk, increment]
+  publisher_id int [ref: > publishers.id]
+  isbn varchar [unique, note: 'ISBNコード']
+  title varchar [note: '書籍名']
+  author varchar [note: '筆者']
+  publish_date date [note: '出版日時']
+  image_url varchar [note: '画像URL']
+  description text [note: '概要']
+  price decimal [note: '価格']
+}
+
+// 本とジャンルの多対多の関係
+// ジャンルとは、PHP, Rust, 設計,,,などの細かい分類を指す
+Table genres {
+  id int [pk, increment] // 主キーと自動増加
+  name varchar [note: 'ジャンル名']
+}
+
+Table book_genre {
+  book_id int [ref: > books.id]
+  genre_id int [ref: > genres.id]
+}
+
+Table publishers {
+  id int [pk, increment]
+  name varchar [note: '出版社名']
+}
+
+// 本とカテゴリの多対多の関係
+// ジャンルとは異なり、IT, コンピューターなどの大雑把なカテゴリを指す
+Table category {
+  id int [pk, increment]
+  name varchar [note: 'カテゴリー名']
+}
+
+Table book_category {
+  book_id int [ref: > books.id]
+  category_id int [ref: > category.id]
+}

--- a/database/database_schema.dbml
+++ b/database/database_schema.dbml
@@ -36,12 +36,12 @@ Table publishers {
 
 // 本とカテゴリの多対多の関係
 // ジャンルとは異なり、IT, コンピューターなどの大雑把なカテゴリを指す
-Table category {
+Table categories {
   id int [pk, increment]
   name varchar [note: 'カテゴリー名']
 }
 
 Table book_category {
   book_id int [ref: > books.id]
-  category_id int [ref: > category.id]
+  category_id int [ref: > categories.id]
 }

--- a/database/migrations/2024_01_10_143025_create_books_table.php
+++ b/database/migrations/2024_01_10_143025_create_books_table.php
@@ -23,9 +23,6 @@ return new class extends Migration
             $table->string('image_url')->nullable();
             $table->dateTime('published_date');
             $table->timestamps();
-
-            // 出版社idに外部キー制約を付与 出版社テーブルがまだないのでコメントアウト
-            // $table->foreign('publisher_id')->references('id')->on('publishers');
         });
     }
 

--- a/database/migrations/2024_01_10_143025_create_books_table.php
+++ b/database/migrations/2024_01_10_143025_create_books_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('books', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('publisher_id');
+            $table->string('title');
+            $table->string('author'); // 筆者は複数いるパターンがあるので、author_id は使わない
+            $table->string('isbn')->unique();
+            $table->string('cover')->nullable();
+            $table->text('description')->nullable();
+            $table->decimal('price')->nullable();
+            $table->string('image_url')->nullable();
+            $table->dateTime('published_date');
+            $table->timestamps();
+
+            // 出版社idに外部キー制約を付与 出版社テーブルがまだないのでコメントアウト
+            // $table->foreign('publisher_id')->references('id')->on('publishers');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('books');
+    }
+};

--- a/database/migrations/2024_01_10_152350_create_publishers_table.php
+++ b/database/migrations/2024_01_10_152350_create_publishers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('publishers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('publishers');
+    }
+};

--- a/database/migrations/2024_01_10_152513_add_foreign_key_for_books_table20241011.php
+++ b/database/migrations/2024_01_10_152513_add_foreign_key_for_books_table20241011.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('books', function (Blueprint $table) {
+            // 出版社idに外部キー制約を付与
+            $table->foreign('publisher_id')->references('id')->on('publishers');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('books', function (Blueprint $table) {
+            // 出版社idの外部キー制約を削除
+            $table->dropForeign(['publisher_id']);
+        });
+    }
+};

--- a/database/migrations/2024_01_10_152601_create_genres_table.php
+++ b/database/migrations/2024_01_10_152601_create_genres_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('genres', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('genres');
+    }
+};

--- a/database/migrations/2024_01_10_152635_create_book_genres_table.php
+++ b/database/migrations/2024_01_10_152635_create_book_genres_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('book_genre', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('book_id');
+            $table->unsignedBigInteger('genre_id');
+            $table->timestamps();
+
+            // 本idに外部キー制約を付与
+            $table->foreign('book_id')->references('id')->on('books');
+            // ジャンルidに外部キー制約を付与
+            $table->foreign('genre_id')->references('id')->on('genres');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('book_genre');
+    }
+};

--- a/database/migrations/2024_01_10_153413_create_categories_table.php
+++ b/database/migrations/2024_01_10_153413_create_categories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique(); // カテゴリ名
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2024_01_10_153435_create_book_categories_table.php
+++ b/database/migrations/2024_01_10_153435_create_book_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('book_category', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('book_id'); // 本id
+            $table->unsignedBigInteger('category_id'); // カテゴリid
+            $table->timestamps();
+
+            // 本idに外部キー制約を付与
+            $table->foreign('book_id')->references('id')->on('books');
+            // カテゴリidに外部キー制約を付与
+            $table->foreign('category_id')->references('id')->on('categories');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('book_categories');
+    }
+};


### PR DESCRIPTION
書籍のデータを登録していくために Model とテーブル定義のマイグレーションファイルを作成

・Book
・Category
・Genre
・Publisher
およびそれらの中間テーブルも定義

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- アプリケーション内の書籍、出版社、カテゴリー、ジャンルのモデルを導入し、関連データへのアクセスを可能にしました。

- **データベース更新**
	- 書籍、出版社、ジャンル、カテゴリーなどのテーブルを含むデータベーススキーマを定義しました。
	- 書籍テーブルに出版社IDの外部キー制約を追加しました。

- **バグ修正**
	- まだ存在しない「publishers」テーブルに関する外部キー制約をコメントアウトすることで、マイグレーション時の問題を解消しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->